### PR TITLE
[DEVOPS-2800] jenkins module fails to get jobs due to node status

### DIFF
--- a/jenkins/__init__.py
+++ b/jenkins/__init__.py
@@ -1451,6 +1451,9 @@ class Jenkins(object):
                 node_name = node['name']
             try:
                 info = self.get_node_info(node_name, depth=2)
+            except NotFoundException:
+                logging.warning('Ignoring node not found: ' + node_name)
+                continue
             except JenkinsException as e:
                 # Jenkins may 500 on depth >0. If the node info comes back
                 # at depth 0 treat it as a node not running any jobs.
@@ -1507,9 +1510,9 @@ class Jenkins(object):
             if response:
                 return json.loads(response)
             else:
-                raise JenkinsException('node[%s] does not exist' % name)
+                raise NotFoundException('node[%s] does not exist' % name)
         except (req_exc.HTTPError, NotFoundException):
-            raise JenkinsException('node[%s] does not exist' % name)
+            raise NotFoundException('node[%s] does not exist' % name)
         except ValueError:
             raise JenkinsException("Could not parse JSON info for node[%s]"
                                    % name)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = yb-python-jenkins
-version = 1.7.1002
+version = 1.7.1003
 author = Ken Conley
 author_email = kwc@willowgarage.com
 summary = Python bindings for the remote Jenkins API


### PR DESCRIPTION
A node not found error should not cause a failure in getting list of running jobs.

Adding some logging to jenkins_manager, gets result with this fix:

```
[2023-08-28 16:10:02,811 build_starter.py:103 INFO] Getting running builds
[2023-08-28 16:10:20,352 __init__.py:1455 WARNING] Ignoring node not found: alma8-gcp-cloud-jenkins-worker-v0upol
[2023-08-28 16:10:32,519 build_starter.py:105 INFO] Got builds: 168
```
